### PR TITLE
Fix header spelling

### DIFF
--- a/components/documents/FolderFilesModal.tsx
+++ b/components/documents/FolderFilesModal.tsx
@@ -132,7 +132,7 @@ export default function DocumentManagementPage({
           <thead>
             <tr className="text-gray-500 text-sm border-b">
               <th className="py-2">Nome do Documento</th>
-              <th>Categoría</th>
+              <th>Categoria</th>
               <th>Tipo</th>
               <th>Tamanho</th>
               <th>Atualizado</th>


### PR DESCRIPTION
## Summary
- fix a misspelled table header label in FolderFilesModal

## Testing
- `npm run lint` *(fails: next not found)*