### PR TITLE
Move interfaces to dedicated types files

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,20 +7,7 @@ import { Bot, Search, Upload, Palette, History } from "lucide-react";
 import { useChat } from "@/hooks/useChat";
 import ChatWindow from "@/components/chat/ChatWindow";
 import ChatInput from "@/components/chat/ChatInput";
-
-interface Assistant {
-  id: string;
-  name: string;
-  description: string;
-  greeting: string;
-}
-
-interface ChatHistory {
-  id: string;
-  title: string;
-  date: string;
-  assistantId: string;
-}
+import type { Assistant, ChatHistory } from "@/types/chat";
 
 const CHAT_API_URL = "http://localhost:3001/api/v1";
 

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -24,30 +24,10 @@ import UploadModal from '@/components/documents/UploadModal';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { getFileType, formatFileSize } from '@/utils/fileUtils';
+import type { DocumentItem, CategoryCount, StorageStats } from '@/types/documents';
 
 const NEST_API_URL = "http://localhost:3001/api/v1";
 
-export interface DocumentItem {
-  id: string;
-  name: string;
-  category: string;
-  type: string;
-  size: string;
-  updated: string;
-  url: string;
-}
-
-export interface CategoryCount {
-  name: string;
-  count: number;
-}
-
-export interface StorageStats {
-  total: string;
-  pdf: string;
-  docs: string;
-  sheets: string;
-}
 
 const DocumentsPage: FC = () => {
   const [documents, setDocuments] = useState<DocumentItem[]>([]);

--- a/components/agents/AgentForm.tsx
+++ b/components/agents/AgentForm.tsx
@@ -9,29 +9,13 @@ import IngestionTab from "./IngestionTab";
 import ModelTab from "@/components/agents/ModelTab";
 import PermissionsTab from "@/components/agents/PermissionsTab";
 import { MOCK_USERS, MOCK_TEAMS } from "@/mocks/mockData";
-
-export interface MyDocument { id: string; name: string; }
+import type {
+  MyDocument,
+  AgentData,
+  AgentFormProps,
+  ToastData,
+} from "@/types/agents";
 type Tab = "basic" | "knowledge" | "ingestion" | "model" | "permissions";
-
-export interface AgentData {
-  id: string;
-  name: string;
-  description?: string;
-  tags?: string;
-  status?: "active" | "inactive";
-  documentIds?: string[];
-}
-
-interface AgentFormProps {
-  onCancel: () => void;
-  myDocuments: MyDocument[];
-  mode?: "create" | "edit";
-  agent?: AgentData | null;
-  onSave?: () => void;
-
-}
-
-interface ToastData { title: string; description: string; }
 
 const tabs: { value: Tab; label: string }[] = [
   { value: "basic", label: "Dados Básicos" },

--- a/components/agents/AgentList.tsx
+++ b/components/agents/AgentList.tsx
@@ -13,25 +13,18 @@ import Toast from "@/components/ui/Toast";
 import NewAgentModal from "./NewAgentModal";
 import EditAgentModal from "./EditAgentModal";
 import IntegrationModal from "./IntegrationModal";
-
-interface Agent {
-  id: string;
-  name: string;
-  status: "active" | "inactive";
-  documentsCount: number;
-  createdAt: string; 
-}
+import type { AgentListItem } from "@/types/agents";
 
 const NEST_API_URL = "http://localhost:3001/api/v1";
 
 const AgentList: React.FC = () => {
-  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agents, setAgents] = useState<AgentListItem[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [toast, setToast] = useState<{ title: string; description: string } | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [deleteModal, setDeleteModal] = useState<{ show: boolean; agentId: string | null }>({ show: false, agentId: null });
-  const [agentToEdit, setAgentToEdit] = useState<Agent | null>(null);
-  const [agentForIntegration, setAgentForIntegration] = useState<Agent | null>(null);
+  const [agentToEdit, setAgentToEdit] = useState<AgentListItem | null>(null);
+  const [agentForIntegration, setAgentForIntegration] = useState<AgentListItem | null>(null);
 
 
   const fetchAgents = async () => {

--- a/components/agents/ApiTab.tsx
+++ b/components/agents/ApiTab.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react';
 import { Server, Copy as CopyIcon, Eye, EyeOff } from 'lucide-react';
 import Switch from '@/components/ui/Switch';
-
-export interface ApiTabProps {
-  apiToken: string;
-  isApiActive: boolean;
-  onGenerateToken(): void;
-  onApiToggle(active: boolean): void;
-}
+import type { ApiTabProps } from '@/types/agents';
 
 const ApiTab: React.FC<ApiTabProps> = ({
   apiToken,

--- a/components/agents/BasicTab.tsx
+++ b/components/agents/BasicTab.tsx
@@ -1,16 +1,6 @@
 import React from "react";
 import Switch from "@/components/ui/Switch";
-
-export interface BasicTabProps {
-  name: string;
-  onNameChange: (value: string) => void;
-  description: string;
-  onDescriptionChange: (value: string) => void;
-  tags: string;
-  onTagsChange: (value: string) => void;
-  status: "active" | "inactive";
-  onStatusChange: (value: "active" | "inactive") => void;
-}
+import type { BasicTabProps } from "@/types/agents";
 
 const labelClasses = "block text-sm font-medium text-gray-700 mb-1.5";
 const inputClasses =

--- a/components/agents/EditAgentModal.tsx
+++ b/components/agents/EditAgentModal.tsx
@@ -1,17 +1,10 @@
 "use client";
 
 import React from "react";
-import AgentForm, { MyDocument, AgentData } from "./AgentForm";
+import AgentForm from "./AgentForm";
+import type { MyDocument, AgentData, EditAgentModalProps } from "@/types/agents";
 
 
-interface EditAgentModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  agent: AgentData | null;
-  myDocuments?: MyDocument[];
-  onSaved?: () => void;
-
-}
 
 const EditAgentModal: React.FC<EditAgentModalProps> = ({
   isOpen,

--- a/components/agents/IngestionTab.tsx
+++ b/components/agents/IngestionTab.tsx
@@ -1,15 +1,5 @@
 import React from "react";
-
-export interface IngestionTabProps {
-  cron: string;
-  onCronChange: (value: string) => void;
-  chunkSize: string;
-  onChunkSizeChange: (value: string) => void;
-  chunkOverlap: string;
-  onChunkOverlapChange: (value: string) => void;
-  embeddingModel: string;
-  onEmbeddingModelChange: (value: string) => void;
-}
+import type { IngestionTabProps } from "@/types/agents";
 
 const labelClasses = "block text-sm font-medium text-gray-700 mb-1.5";
 const inputClasses =

--- a/components/agents/IntegrationModal.tsx
+++ b/components/agents/IntegrationModal.tsx
@@ -6,13 +6,7 @@ import WebhookTab from "./WebhookTab";
 import ApiTab from "./ApiTab";
 import WidgetTab from "./WidgetTab";
 import ExternalTab from "./ExternalTab";
-import { AgentData } from "./AgentForm";
-
-interface IntegrationModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  agent: AgentData | null;
-}
+import type { AgentData, IntegrationModalProps } from "@/types/agents";
 
 type Tab = "webhook" | "api" | "widget" | "external";
 const tabs: { value: Tab; label: string; icon: React.ReactNode }[] = [

--- a/components/agents/KnowledgeTab.tsx
+++ b/components/agents/KnowledgeTab.tsx
@@ -1,18 +1,7 @@
 import React, { ChangeEvent, useRef } from "react";
 import { Upload, Database as DatabaseIcon, FileText } from "lucide-react";
-import type { MyDocument } from "@/components/agents/AgentForm";
+import type { MyDocument, KnowledgeTabProps } from "@/types/agents";
 
-export interface KnowledgeTabProps {
-  onFilesChange: (files: FileList | null) => void;
-  sourceUrl: string;
-  onSourceUrlChange: (value: string) => void;
-  onAddUrl: () => void;
-  myDocuments: MyDocument[];
-  selectedDocs: string[];
-  onSelectedDocsChange: (docs: string[]) => void;
-  onConnectSharePoint: () => void;
-  onConnectGoogleDrive: () => void;
-}
 
 const labelClasses = "block text-sm font-medium text-gray-700 mb-1";
 const inputClasses = "mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-purple-500 focus:ring-2 focus:ring-purple-500/40 transition-all";

--- a/components/agents/ModelTab.tsx
+++ b/components/agents/ModelTab.tsx
@@ -1,27 +1,7 @@
 import React from "react";
 import Switch from "@/components/ui/Switch";
+import type { ModelOption, ModelTabProps } from "@/types/agents";
 
-export interface ModelOption {
-  value: string;
-  label: string;
-}
-
-export interface ModelTabProps {
-  provider: "openai" | "anthropic" | "ollama" | "grok" | "gemini" | "custom";
-  onProviderChange: (key: ModelTabProps['provider']) => void;
-  specificModel: string;
-  onSpecificModelChange: (value: string) => void;
-  temperature: number;
-  onTemperatureChange: (value: number) => void;
-  topK: string;
-  onTopKChange: (value: string) => void;
-  systemPrompt: string;
-  onSystemPromptChange: (value: string) => void;
-  vectorDb: "chroma" | "supabase" | "pinecone" | "qdrant" | "weaviate";
-  onVectorDbChange: (key: ModelTabProps['vectorDb']) => void;
-  apiKey: string;
-  onApiKeyChange: (value: string) => void;
-}
 
 // Modelos disponíveis por provedor
 // Garantimos que todas as chaves de `provider` possuam um array padrão

--- a/components/agents/NewAgentModal.tsx
+++ b/components/agents/NewAgentModal.tsx
@@ -2,13 +2,8 @@
 "use client";
 
 import React from "react";
-import AgentForm, { MyDocument } from "./AgentForm";
-
-interface NewAgentModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  myDocuments?: MyDocument[];
-}
+import AgentForm from "./AgentForm";
+import type { MyDocument, NewAgentModalProps } from "@/types/agents";
 
 const NewAgentModal: React.FC<NewAgentModalProps> = ({
   isOpen,

--- a/components/agents/PermissionsTab.tsx
+++ b/components/agents/PermissionsTab.tsx
@@ -1,25 +1,6 @@
 import React from "react";
+import type { PermissionsTabOption, PermissionsTabProps } from "@/types/agents";
 
-export interface Option {
-  id: string;
-  name: string;
-}
-
-export interface PermissionsTabProps {
-  userSearch: string;
-  onUserSearchChange: (value: string) => void;
-  onAddUser: () => void;
-  selectedUsers: string[]; // armazena os ids dos usuários selecionados
-  onRemoveUser: (userId: string) => void;
-  users: Option[];
-
-  teamSearch: string;
-  onTeamSearchChange: (value: string) => void;
-  onAddTeam: () => void;
-  selectedTeams: string[]; // armazena os ids das equipes selecionadas
-  onRemoveTeam: (teamId: string) => void;
-  teams: Option[];
-}
 
 const PermissionsTab: React.FC<PermissionsTabProps> = ({
   userSearch,

--- a/components/agents/WebhookTab.tsx
+++ b/components/agents/WebhookTab.tsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
 import { Shield, AlertCircle, CheckCircle, Copy, Eye, EyeOff } from 'lucide-react';
-
-// Tipagem das props do Switch
-interface SwitchProps {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  disabled?: boolean;
-}
+import type { SwitchProps } from '@/types/ui';
+import type { WebhookTabProps } from '@/types/agents';
 
 const Switch: React.FC<SwitchProps> = ({ checked, onCheckedChange, disabled = false }) => (
   <button
@@ -29,12 +24,6 @@ const Switch: React.FC<SwitchProps> = ({ checked, onCheckedChange, disabled = fa
   </button>
 );
 
-export interface WebhookTabProps {
-  webhookUrl: string;
-  isWebhookActive: boolean;
-  onWebhookUrlChange: (url: string) => void;
-  onWebhookToggle: (active: boolean) => void;
-}
 
 const WebhookTab: React.FC<WebhookTabProps> = ({
   webhookUrl,

--- a/components/agents/WidgetTab.tsx
+++ b/components/agents/WidgetTab.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react';
 import { Code as CodeIcon, Copy as CopyIcon } from 'lucide-react';
 import Switch from '@/components/ui/Switch';
-
-export interface WidgetTabProps {
-  widgetCode: string;
-  isWidgetActive: boolean;
-  onCopyWidgetCode(): void;
-  onWidgetToggle(active: boolean): void;
-}
+import type { WidgetTabProps } from '@/types/agents';
 
 const WidgetTab: React.FC<WidgetTabProps> = ({
   widgetCode,

--- a/components/chat/MessageBubble.tsx
+++ b/components/chat/MessageBubble.tsx
@@ -1,11 +1,7 @@
 // components/chat/MessageBubble.tsx
 import React, { FC } from "react";
 import { Bot, User } from "lucide-react";
-import { Message } from "@/hooks/useChat";
-
-interface MessageBubbleProps {
-  message: Message;
-}
+import type { Message, MessageBubbleProps } from "@/types/chat";
 
 const MessageBubble: FC<MessageBubbleProps> = ({ message }) => {
   const isUser = message.from === "user";

--- a/components/documents/FolderFilesModal.tsx
+++ b/components/documents/FolderFilesModal.tsx
@@ -8,37 +8,12 @@ import {
   Loader2,
 } from "lucide-react";
 import { decodeFileName } from "@/utils/decodeFileName";
-
-export interface DocumentItem {
-  id: string;
-  name: string;
-  category: string;
-  type: string;
-  size: string;
-  updated: string;
-  url: string;
-}
-
-export interface CategoryCount {
-  name: string;
-  count: number;
-}
-
-export interface StorageStats {
-  total: string;
-  pdf: string;
-  docs: string;
-  sheets: string;
-}
-
-interface DocumentManagementPageProps {
-  documents: DocumentItem[];
-  recentDocuments: DocumentItem[];
-  categories: CategoryCount[];
-  storage: StorageStats;
-  onDelete: (id: string) => void;
-  onUpload: (files: FileList) => Promise<void>;
-}
+import type {
+  DocumentItem,
+  CategoryCount,
+  StorageStats,
+  DocumentManagementPageProps,
+} from "@/types/documents";
 
 export default function DocumentManagementPage({
   documents,

--- a/components/documents/UploadModal.tsx
+++ b/components/documents/UploadModal.tsx
@@ -1,23 +1,6 @@
 import React from "react";
 import { UploadCloud, X } from "lucide-react";
-
-interface UploadModalProps {
-  open: boolean;
-  onClose: () => void;
-  onSubmit: (formData: FormData) => Promise<void>;
-  uploadData: {
-    name: string;
-    category: string;
-    description: string;
-    file: File | null;
-  };
-  setUploadData: React.Dispatch<React.SetStateAction<{
-    name: string;
-    category: string;
-    description: string;
-    file: File | null;
-  }>>;
-}
+import type { UploadModalProps } from "@/types/documents";
 
 const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uploadData, setUploadData }) => {
   if (!open) return null;

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,26 +1,9 @@
 // src/components/ui/Select.tsx
 "use client";
 
-import React, {
-  forwardRef,
-  SelectHTMLAttributes,
-  ReactNode
-} from "react";
+import React, { forwardRef } from "react";
+import type { SelectProps } from "@/types/ui";
 
-export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
-  /**
-   * Arrays de opções para exibição. Se fornecido, renderiza automaticamente <option>.
-   */
-  options?: { value: string; label: string }[];
-  /**
-   * Se preferir passar manualmente <option> como children.
-   */
-  children?: ReactNode;
-  /**
-   * Classe Tailwind opcional para customização.
-   */
-  className?: string;
-}
 
 const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ options, children, className = "", ...props }, ref) => {

--- a/components/ui/StatusBadge.tsx
+++ b/components/ui/StatusBadge.tsx
@@ -1,10 +1,7 @@
 // components/agents/StatusBadge.tsx
 import React from "react";
 import { AgentStatus } from "@/types/agents";
-
-interface StatusBadgeProps {
-  status: AgentStatus;
-}
+import type { StatusBadgeProps } from "@/types/ui";
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
   const isActive = status === "Ativo";

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,11 +1,5 @@
 import React from "react";
-
-export interface SwitchProps {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  /** Se true, o switch fica desabilitado */
-  disabled?: boolean;
-}
+import type { SwitchProps } from "@/types/ui";
 
 const Switch: React.FC<SwitchProps> = ({ checked, onCheckedChange, disabled = false }) => {
   return (

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect } from "react";
 import { X } from "lucide-react"; // ícone de fechar
-
-interface ToastProps {
-  title: string;
-  description: string;
-  onClose: () => void;
-}
+import type { ToastProps } from "@/types/ui";
 
 const Toast: React.FC<ToastProps> = ({ title, description, onClose }) => {
   useEffect(() => {

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,13 +1,6 @@
 // hooks/useChat.ts
 import { useState, useRef, useLayoutEffect, useCallback } from "react";
-
-// Define o tipo de uma mensagem
-export interface Message {
-  id: string;
-  from: "user" | "bot";
-  text: string;
-  timestamp: string;
-}
+import type { Message } from "@/types/chat";
 
 export function useChat(initialPrompt: string) {
   // --------------------------

--- a/mocks/mockData.ts
+++ b/mocks/mockData.ts
@@ -1,9 +1,6 @@
 // mocks/mockData.ts
 
-export interface TestEntity {
-  id: string;
-  name: string;
-}
+import type { TestEntity } from "@/types/mock";
 
 export const MOCK_USERS: TestEntity[] = [
   { id: "u1", name: "João Silva" },

--- a/types/agents.ts
+++ b/types/agents.ts
@@ -8,3 +8,150 @@ export interface Agent {
   documents: number;
   updatedAt: string;
 }
+
+export interface MyDocument { id: string; name: string; }
+
+export interface AgentData {
+  id: string;
+  name: string;
+  description?: string;
+  tags?: string;
+  status?: "active" | "inactive";
+  documentIds?: string[];
+}
+
+export interface AgentFormProps {
+  onCancel: () => void;
+  myDocuments: MyDocument[];
+  mode?: "create" | "edit";
+  agent?: AgentData | null;
+  onSave?: () => void;
+}
+
+export interface ToastData { title: string; description: string; }
+
+export interface ApiTabProps {
+  apiToken: string;
+  isApiActive: boolean;
+  onGenerateToken(): void;
+  onApiToggle(active: boolean): void;
+}
+
+export interface BasicTabProps {
+  name: string;
+  onNameChange: (value: string) => void;
+  description: string;
+  onDescriptionChange: (value: string) => void;
+  tags: string;
+  onTagsChange: (value: string) => void;
+  status: "active" | "inactive";
+  onStatusChange: (value: "active" | "inactive") => void;
+}
+
+export interface EditAgentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  agent: AgentData | null;
+  myDocuments?: MyDocument[];
+  onSaved?: () => void;
+}
+
+export interface IngestionTabProps {
+  cron: string;
+  onCronChange: (value: string) => void;
+  chunkSize: string;
+  onChunkSizeChange: (value: string) => void;
+  chunkOverlap: string;
+  onChunkOverlapChange: (value: string) => void;
+  embeddingModel: string;
+  onEmbeddingModelChange: (value: string) => void;
+}
+
+export interface KnowledgeTabProps {
+  onFilesChange: (files: FileList | null) => void;
+  sourceUrl: string;
+  onSourceUrlChange: (value: string) => void;
+  onAddUrl: () => void;
+  myDocuments: MyDocument[];
+  selectedDocs: string[];
+  onSelectedDocsChange: (docs: string[]) => void;
+  onConnectSharePoint: () => void;
+  onConnectGoogleDrive: () => void;
+}
+
+export interface ModelOption {
+  value: string;
+  label: string;
+}
+
+export interface ModelTabProps {
+  provider: "openai" | "anthropic" | "ollama" | "grok" | "gemini" | "custom";
+  onProviderChange: (key: ModelTabProps['provider']) => void;
+  specificModel: string;
+  onSpecificModelChange: (value: string) => void;
+  temperature: number;
+  onTemperatureChange: (value: number) => void;
+  topK: string;
+  onTopKChange: (value: string) => void;
+  systemPrompt: string;
+  onSystemPromptChange: (value: string) => void;
+  vectorDb: "chroma" | "supabase" | "pinecone" | "qdrant" | "weaviate";
+  onVectorDbChange: (key: ModelTabProps['vectorDb']) => void;
+  apiKey: string;
+  onApiKeyChange: (value: string) => void;
+}
+
+export interface NewAgentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  myDocuments?: MyDocument[];
+}
+
+export interface PermissionsTabOption {
+  id: string;
+  name: string;
+}
+
+export interface PermissionsTabProps {
+  userSearch: string;
+  onUserSearchChange: (value: string) => void;
+  onAddUser: () => void;
+  selectedUsers: string[];
+  onRemoveUser: (userId: string) => void;
+  users: PermissionsTabOption[];
+
+  teamSearch: string;
+  onTeamSearchChange: (value: string) => void;
+  onAddTeam: () => void;
+  selectedTeams: string[];
+  onRemoveTeam: (teamId: string) => void;
+  teams: PermissionsTabOption[];
+}
+
+export interface WidgetTabProps {
+  widgetCode: string;
+  isWidgetActive: boolean;
+  onCopyWidgetCode(): void;
+  onWidgetToggle(active: boolean): void;
+}
+
+export interface WebhookTabProps {
+  webhookUrl: string;
+  isWebhookActive: boolean;
+  onWebhookUrlChange: (url: string) => void;
+  onWebhookToggle: (active: boolean) => void;
+}
+
+export interface IntegrationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  agent: AgentData | null;
+}
+
+export interface AgentListItem {
+  id: string;
+  name: string;
+  status: "active" | "inactive";
+  documentsCount: number;
+  createdAt: string;
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -23,5 +23,19 @@ export interface Message {
   
   export interface MessageBubbleProps {
     message: Message;
-  }  
+  }
+
+export interface Assistant {
+  id: string;
+  name: string;
+  description: string;
+  greeting: string;
+}
+
+export interface ChatHistory {
+  id: string;
+  title: string;
+  date: string;
+  assistantId: string;
+}
   

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -1,0 +1,52 @@
+import type React from "react";
+
+export interface DocumentItem {
+  id: string;
+  name: string;
+  category: string;
+  type: string;
+  size: string;
+  updated: string;
+  url: string;
+}
+
+export interface CategoryCount {
+  name: string;
+  count: number;
+}
+
+export interface StorageStats {
+  total: string;
+  pdf: string;
+  docs: string;
+  sheets: string;
+}
+
+export interface DocumentManagementPageProps {
+  documents: DocumentItem[];
+  recentDocuments: DocumentItem[];
+  categories: CategoryCount[];
+  storage: StorageStats;
+  onDelete: (id: string) => void;
+  onUpload: (files: FileList) => Promise<void>;
+}
+
+export interface UploadModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (formData: FormData) => Promise<void>;
+  uploadData: {
+    name: string;
+    category: string;
+    description: string;
+    file: File | null;
+  };
+  setUploadData: React.Dispatch<
+    React.SetStateAction<{
+      name: string;
+      category: string;
+      description: string;
+      file: File | null;
+    }>
+  >;
+}

--- a/types/mock.ts
+++ b/types/mock.ts
@@ -1,0 +1,4 @@
+export interface TestEntity {
+  id: string;
+  name: string;
+}

--- a/types/ui.ts
+++ b/types/ui.ts
@@ -1,0 +1,28 @@
+import type { SelectHTMLAttributes, ReactNode } from "react";
+import type { AgentStatus } from "./agents";
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  /** Arrays de opções para exibição. Se fornecido, renderiza automaticamente <option>. */
+  options?: { value: string; label: string }[];
+  /** Se preferir passar manualmente <option> como children. */
+  children?: ReactNode;
+  /** Classe Tailwind opcional para customização. */
+  className?: string;
+}
+
+export interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /** Se true, o switch fica desabilitado */
+  disabled?: boolean;
+}
+
+export interface ToastProps {
+  title: string;
+  description: string;
+  onClose: () => void;
+}
+
+export interface StatusBadgeProps {
+  status: AgentStatus;
+}


### PR DESCRIPTION
## Summary
- revert prior interface->type alias change
- centralize all interface definitions under `types` directory
- update components and pages to import interfaces from new location

## Testing
- `npm run lint` *(fails: `next` not found)*