### PR TITLE
Fix expandedSection state type

### DIFF
--- a/components/agents/WebhookTab.tsx
+++ b/components/agents/WebhookTab.tsx
@@ -66,7 +66,8 @@ const WebhookTab: React.FC<WebhookTabProps & { agent: AgentData }> = ({
 }) => {
   const [showUrl, setShowUrl] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [expandedSection, setExpandedSection] = useState(null);
+  const [expandedSection, setExpandedSection] =
+    useState<'events' | 'examples' | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState('success'); // idle, testing, success, error
   const [lastTestResult, setLastTestResult] = useState({


### PR DESCRIPTION
## Summary
- broaden `expandedSection` state type to allow string values

## Testing
- `npm run lint` *(fails: next not found)*