### PR TITLE
Fix Switch typing in WidgetTab

### DIFF
--- a/components/agents/WidgetTab.tsx
+++ b/components/agents/WidgetTab.tsx
@@ -22,7 +22,15 @@ import {
 } from 'lucide-react';
 
 // Mock Switch component
-const Switch = ({ checked, onCheckedChange, disabled }) => (
+const Switch = ({
+  checked,
+  onCheckedChange,
+  disabled,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled: boolean;
+}) => (
   <button
     onClick={() => !disabled && onCheckedChange(!checked)}
     disabled={disabled}


### PR DESCRIPTION
## Summary
- add prop types to WidgetTab switch

## Testing
- `npm run lint` *(fails: next not found)*