### PR TITLE
Add agent id to chat request

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -7,6 +7,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     console.log('[api/chat] request body:', body);
     const question = body.question;
+    const agentId = body.agentId;
     if (!question) {
       return NextResponse.json({ error: 'Pergunta não informada.' }, { status: 400 });
     }
@@ -17,7 +18,7 @@ export async function POST(request: NextRequest) {
     const apiResponse = await fetch(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question }),
+      body: JSON.stringify({ question, agentId }),
     });
 
     const text = await apiResponse.text();

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -59,7 +59,10 @@ const ChatPage: FC = () => {
     sendMessage,
     textareaRef,
     endRef,
-  } = useChat(selectedAssistant?.greeting || "Olá! Como posso ajudar?");
+  } = useChat(
+    selectedAssistant?.greeting || "Olá! Como posso ajudar?",
+    selectedAssistant?.id
+  );
 
   const userName = "Josué Celeste";
   const handleLogout = () => console.log("Logout");

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,8 +1,8 @@
 // hooks/useChat.ts
-import { useState, useRef, useLayoutEffect, useCallback } from "react";
+import { useState, useRef, useLayoutEffect, useCallback, useEffect } from "react";
 import type { Message } from "@/types/chat";
 
-export function useChat(initialPrompt: string) {
+export function useChat(initialPrompt: string, agentId?: string) {
   // --------------------------
   // ESTADOS & REFS
   // --------------------------
@@ -20,6 +20,11 @@ export function useChat(initialPrompt: string) {
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const endRef = useRef<HTMLDivElement | null>(null);     // usado para scroll automático
+  const agentIdRef = useRef<string | undefined>(agentId);
+
+  useEffect(() => {
+    agentIdRef.current = agentId;
+  }, [agentId]);
 
   // --------------------------
   // FUNÇÕES
@@ -51,7 +56,7 @@ export function useChat(initialPrompt: string) {
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: text }),
+        body: JSON.stringify({ question: text, agentId: agentIdRef.current }),
       });
 
       const payload = await res.json();


### PR DESCRIPTION
## Summary
- send selected agent ID from chat front end to API
- forward agent ID to NestJS RAG backend

## Testing
- `npm run lint` *(fails: `next` not found)*