### PR TITLE
Add agent linking during document upload

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -40,7 +40,8 @@ const DocumentsPage: FC = () => {
   const [editModal, setEditModal] = useState<{ show: boolean; doc: DocumentItem | null }>({ show: false, doc: null });
   const [newName, setNewName] = useState("");
   const [uploadModal, setUploadModal] = useState(false);
-  const [uploadData, setUploadData] = useState({ name: '', category: '', description: '', file: null as File | null });
+  const [uploadData, setUploadData] = useState({ name: '', category: '', description: '', file: null as File | null, agentId: '' });
+  const [agents, setAgents] = useState<{ id: string; name: string }[]>([]);
   const itemsPerPage = 5;
 
   const userName = "Josué Celeste";
@@ -71,6 +72,22 @@ const DocumentsPage: FC = () => {
     loadData();
   }, []);
 
+  useEffect(() => {
+    async function fetchAgents() {
+      try {
+        const res = await fetch(`${NEST_API_URL}/agents`, { credentials: "include" });
+        const data = await res.json();
+        const opts = Array.isArray(data)
+          ? data.map((a: any) => ({ id: a.id, name: a.name }))
+          : [];
+        setAgents(opts);
+      } catch (err) {
+        console.error('Error loading agents', err);
+      }
+    }
+    fetchAgents();
+  }, []);
+
   const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files || files.length === 0) return;
@@ -93,6 +110,9 @@ const DocumentsPage: FC = () => {
 
   const handleUploadCustom = async (formData: FormData) => {
     console.log("Enviando para API NestJS /documents/upload", Array.from(formData.entries()));
+    if (uploadData.agentId) {
+      formData.append('agentId', uploadData.agentId);
+    }
     try {
       const res = await fetch(`${NEST_API_URL}/documents/upload`, { method: "POST", body: formData, credentials: "include" });
       if (!res.ok) throw new Error(`Error ${res.status}`);
@@ -301,6 +321,7 @@ const DocumentsPage: FC = () => {
         onSubmit={handleUploadCustom}
         uploadData={uploadData}
         setUploadData={setUploadData}
+        agents={agents}
       />
 
       <main className="container mx-auto px-4 py-8">

--- a/components/documents/UploadModal.tsx
+++ b/components/documents/UploadModal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { UploadCloud, X } from "lucide-react";
 import type { UploadModalProps } from "@/types/documents";
 
-const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uploadData, setUploadData }) => {
+const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uploadData, setUploadData, agents }) => {
   if (!open) return null;
 
   return (
@@ -36,6 +36,9 @@ const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uplo
             formData.append('name', uploadData.name);
             formData.append('category', uploadData.category);
             formData.append('description', uploadData.description);
+            if (uploadData.agentId) {
+              formData.append('agentId', uploadData.agentId);
+            }
 
             // Log dos dados do formulário
             console.log('Dados do documento:', {
@@ -50,7 +53,7 @@ const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uplo
             });
 
             await onSubmit(formData);
-            setUploadData({ name: '', category: '', description: '', file: null });
+            setUploadData({ name: '', category: '', description: '', file: null, agentId: '' });
             onClose();
           }}
           className="space-y-5"
@@ -78,13 +81,27 @@ const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onSubmit, uplo
 
           <div>
             <label className="block text-sm font-semibold text-gray-700 mb-2">Descrição</label>
-            <textarea
-              className="w-full px-4 py-2.5 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 text-base font-medium placeholder:text-gray-400 min-h-[100px] resize-y"
-              placeholder="Breve descrição do documento"
-              value={uploadData.description}
-              onChange={e => setUploadData({ ...uploadData, description: e.target.value })}
-            />
-          </div>
+          <textarea
+            className="w-full px-4 py-2.5 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 text-base font-medium placeholder:text-gray-400 min-h-[100px] resize-y"
+            placeholder="Breve descrição do documento"
+            value={uploadData.description}
+            onChange={e => setUploadData({ ...uploadData, description: e.target.value })}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-2">Agente</label>
+          <select
+            className="w-full px-4 py-2.5 bg-white text-gray-900 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 text-base font-medium"
+            value={uploadData.agentId}
+            onChange={e => setUploadData({ ...uploadData, agentId: e.target.value })}
+          >
+            <option value="">Selecione um agente</option>
+            {agents.map(agent => (
+              <option key={agent.id} value={agent.id}>{agent.name}</option>
+            ))}
+          </select>
+        </div>
 
           <div>
             <label className="block text-sm font-semibold text-gray-700 mb-2">Arquivo</label>

--- a/types/documents.ts
+++ b/types/documents.ts
@@ -40,6 +40,7 @@ export interface UploadModalProps {
     category: string;
     description: string;
     file: File | null;
+    agentId: string;
   };
   setUploadData: React.Dispatch<
     React.SetStateAction<{
@@ -47,6 +48,8 @@ export interface UploadModalProps {
       category: string;
       description: string;
       file: File | null;
+      agentId: string;
     }>
   >;
+  agents: { id: string; name: string }[];
 }


### PR DESCRIPTION
## Summary
- allow associating documents with a specific agent when uploading
- list agents for selection in upload modal
- send chosen agent with upload request

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*