### PR TITLE
Set Chroma as default vector DB

### DIFF
--- a/components/agents/AgentForm.tsx
+++ b/components/agents/AgentForm.tsx
@@ -61,7 +61,9 @@ const AgentForm: React.FC<AgentFormProps> = ({
   const [systemPrompt, setSystemPrompt] = useState(
     "Você é um assistente AI que responde perguntas de forma útil e precisa."
   );
-  const [vectorDb, setVectorDb] = useState<"chroma" | "supabase" | "pinecone" | "qdrant" | "weaviate">("supabase");
+  const [vectorDb, setVectorDb] = useState<
+    "chroma" | "supabase" | "pinecone" | "qdrant" | "weaviate"
+  >("chroma");
   const [apiKey, setApiKey] = useState("");
   // Permissions
   const [userSearch, setUserSearch] = useState("");


### PR DESCRIPTION
## Summary
- set Chroma as the default vector database in AgentForm

## Testing
- `npm run lint` *(fails: next not found)*